### PR TITLE
Update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ pip install torch-affine-utils
 ### 2D Transformations
 
 ```python
+import einops
 import torch
 from torch_affine_utils.transforms_2d import R, T, S
 
@@ -45,14 +46,19 @@ scaling = S(torch.tensor([[2.0, 3.0]]))
 # Chain transformations (apply scaling, then rotation, then translation)
 transform = translation @ rotation @ scaling
 
-# Apply to coordinates
-coords = torch.tensor([[1.0, 1.0, 1.0]]).T  # Homogeneous coordinates (x, y, w)
+# Apply to a batch of 2D coordinates
+coords = torch.tensor([
+    [1.0, 1.0, 1.0],  # Homogeneous coordinates (x, y, w)
+    [1.0, 0.0, 1.0]
+])  
+coords = einops.rearrange(coords, 'b xyw -> b xyw 1')
 transformed_coords = transform @ coords
 ```
 
 ### 3D Transformations
 
 ```python
+import einops
 import torch
 from torch_affine_utils.transforms_3d import Rx, Ry, Rz, T, S
 
@@ -68,8 +74,12 @@ scaling = S(torch.tensor([[2.0, 2.0, 2.0]]))
 # Chain transformations
 transform = translation @ rot_z @ rot_y @ rot_x @ scaling
 
-# Apply to 3D coordinates
-coords = torch.tensor([[1.0, 1.0, 1.0, 1.0]]).T  # Homogeneous coordinates (x, y, z, w)
+# Apply to a batch of 3D coordinates
+coords = torch.tensor([
+    [1.0, 1.0, 1.0, 1.0],  # Homogeneous coordinates (x, y, z, w)
+    [1.0, 0.0, 0.0, 1.0]
+])
+coords = einops.rearrange(coords, 'b xyzw -> b xyzw 1')
 transformed_coords = transform @ coords
 ```
 

--- a/src/torch_affine_utils/transforms_2d.py
+++ b/src/torch_affine_utils/transforms_2d.py
@@ -105,11 +105,11 @@ def S(scale_factors: torch.Tensor) -> torch.Tensor:
 
      Matrix structure:
     ┌          ┐
-    │ sx 0  0  │
-    │ 0  sy 0  │
+    │ s1 0  0  │
+    │ 0  s2 0  │
     │ 0  0  1  │
     └          ┘
-    where sx, sy are the scaling factors at indices 0, 1 in the last dimension
+    where s1, s2 are the scaling factors at indices 0, 1 in the last dimension
     of `scale_factors`.
 
     Parameters

--- a/src/torch_affine_utils/transforms_3d.py
+++ b/src/torch_affine_utils/transforms_3d.py
@@ -224,13 +224,13 @@ def S(scale_factors: torch.Tensor) -> torch.Tensor:
 
      Matrix structure:
     ┌             ┐
-    │ sx 0  0  0  │
-    │ 0  sy 0  0  │
-    │ 0  0  sz 0  │
+    │ s1 0  0  0  │
+    │ 0  s2 0  0  │
+    │ 0  0  s3 0  │
     │ 0  0  0  1  │
     └             ┘
-    where sx, sy, sz are the scaling factors at indices 0, 1, 2 in the last dimension
-    of `scale_factors`.
+    where s1, s2, s3 are the scaling factors at indices 0, 1, 2 in the last
+    dimension of `scale_factors`.
 
     Parameters
     ----------


### PR DESCRIPTION
Updated the docstrings of scaling matrices to not define x y z order => up to the user now to do it correct. 

I also made a small update in the README which for me improves the readability and makes it clear batched coordinates can be used, but let me know if you agree with that (can revert the commit).

Closes #4.