### PR TITLE
initialized matrix not on same device as parameters

### DIFF
--- a/src/torch_affine_utils/transforms_2d.py
+++ b/src/torch_affine_utils/transforms_2d.py
@@ -45,6 +45,7 @@ def R(angles: torch.Tensor | list | tuple | float,
     """
     angles = torch.as_tensor(angles, dtype=torch.float32)
     device = device or angles.device  # Use provided device or input tensor's device
+    angles = angles.to(device)
     angles_packed, ps = einops.pack([angles], pattern='*')  # to 1d
     n = angles_packed.shape[0]
 
@@ -100,6 +101,7 @@ def T(shifts: torch.Tensor | list | tuple,
         raise ValueError("Shifts must have the last dimension of size 2 for 2D transformations.")
     shifts = torch.atleast_1d(shifts)
     device = device or shifts.device  # Use provided device or input tensor's device
+    shifts = shifts.to(device)
     shifts, ps = einops.pack([shifts], pattern='* coords')  # to 2d
     n = shifts.shape[0]
 
@@ -143,6 +145,7 @@ def S(scale_factors: torch.Tensor | list | tuple | float,
         raise ValueError("Scale factors must have the last dimension of size 2 for 2D transformations.")
     scale_factors = torch.atleast_1d(scale_factors)
     device = device or scale_factors.device  # Use provided device or input tensor's device
+    scale_factors = scale_factors.to(device)
     scale_factors, ps = einops.pack([scale_factors], pattern='* coords')  # to 2d
     n = scale_factors.shape[0]
 


### PR DESCRIPTION
explicitly move all parameter tensor to device to ensure that they live in the same spaces as the initialized matrices